### PR TITLE
CP2K containers

### DIFF
--- a/CP2K/ci-cpu.yml
+++ b/CP2K/ci-cpu.yml
@@ -1,0 +1,41 @@
+build cp2k-develop cpu image:
+  extends: .build-image
+  variables:
+    DOCKERFILE: CP2K/gcc-mkl-cpu/Dockerfile
+    NAME_TAG: 'cp2k-develop-cpu'
+build cp2k-develop nvidia image:
+  extends: .build-image
+  variables:
+    DOCKERFILE: CP2K/gcc-mkl-gpu/nvidia.Dockerfile
+    NAME-TAG: 'cp2k-develop-gpu'
+build cp2k-develop amd image:
+  extends: .build-image
+  variables:
+    DOCKERFILE: CP2K/gcc-mkl-gpu/AMD.Dockerfile
+
+#run cp2k develop hohgant cpu mpi-hook:
+#  extends: .run-test-hohgant-cpu
+#  needs: ["build cp2k-develop cpu image"]
+#  variables:
+#    USE_MPI: 'YES'
+#    SLURM_JOB_NUM_NODES: 1
+#    SLURM_CPUS_PER_TASK: 8
+#    OMP_NUM_THREADS: $SLURM_CPUS_PER_TASK
+#    SLURM_NTASKS: 16
+#  script:
+#    - cd SIRIUS/test/Si63Ge
+#    - /opt/sirius-cpu/bin/sirius.scf --control.mpi_grid_dims=2:2 --control.std_evp_solver_name=scalapack --control.gen_evp_solver_name=scalapack --test_against=output_ref.json
+
+#run cp2k develop hohgant cpu:
+#  extends: .run-test-hohgant-cpu
+#  needs: ["build sirius-develop cpu image"]
+#  variables:
+#    USE_MPI: 'NO'
+#    SLURM_JOB_NUM_NODES: 1
+#    SLURM_CPUS_PER_TASK: 8
+#    OMP_NUM_THREADS: $SLURM_CPUS_PER_TASK
+#    SLURM_NTASKS: 16
+#  script:
+#    - cd SIRIUS/test/Si63Ge
+#    - /opt/sirius-cpu/bin/sirius.scf --control.mpi_grid_dims=2:2 --control.std_evp_solver_name=scalapack --control.gen_evp_solver_name=scalapack --test_against=output_ref.json
+

--- a/CP2K/ci.yml
+++ b/CP2K/ci.yml
@@ -1,0 +1,72 @@
+include:
+  - local: '/ci/common.yml'
+
+build cp2k-develop image:
+  extends: .build-image
+  variables:
+    CSCS_REBUILD_POLICY: always
+    DOCKERFILE: CP2K/gcc-mkl/Dockerfile
+    NAME_TAG: 'cp2k-develop'
+    DOCKER_BUILD_ARGS: '["CUDA_ARCH=80"]'
+
+#run sirius develop hohgant cpu:
+#  extends: .run-test-hohgant-cpu
+#  needs: ["build sirius-develop image"]
+#  variables:
+#    SLURM_JOB_NUM_NODES: 1
+#    SLURM_CPUS_PER_TASK: 8
+#    OMP_NUM_THREADS: $SLURM_CPUS_PER_TASK
+#    SLURM_NTASKS: 16
+#  script:
+#    - cd SIRIUS/test/Si63Ge
+#    - /opt/sirius-cpu/bin/sirius.scf --control.mpi_grid_dims=2:2 --control.std_evp_solver_name=scalapack --control.gen_evp_solver_name=scalapack --test_against=output_ref.json
+
+#run sirius develop hohgant cpu mpi-hook:
+#  extends: .run-test-hohgant-cpu
+#  needs: ["build cp2k-develop image"]
+#  variables:
+#    USE_MPI: 'YES'
+#    SLURM_JOB_NUM_NODES: 1
+#    SLURM_CPUS_PER_TASK: 8
+#    OMP_NUM_THREADS: $SLURM_CPUS_PER_TASK
+#    SLURM_NTASKS: 16
+#  script:
+#    - cd SIRIUS/test/Si63Ge
+#    - /opt/sirius-cpu/bin/sirius.scf --control.mpi_grid_dims=2:2 --control.std_evp_solver_name=scalapack --control.gen_evp_solver_name=scalapack --test_against=output_ref.json
+
+#run cp2k develop hohgant r1 a100:
+#  extends: .run-test-hohgant-a100
+#  needs: ["build cp2k-develop image"]
+#  variables:
+#    SLURM_JOB_NUM_NODES: 1
+#    SLURM_CPUS_PER_TASK: 16
+#    OMP_NUM_THREADS: $SLURM_CPUS_PER_TASK
+#    SLURM_NTASKS: 1
+#  script:
+#    - cd SIRIUS/test/Si63Ge
+#    - /opt/sirius-gpu/bin/sirius.scf
+
+#run cp2k develop hohgant a100:
+#  extends: .run-test-hohgant-a100
+#  needs: ["build cp2k-develop image"]
+#  variables:
+#    SLURM_JOB_NUM_NODES: 1
+#    SLURM_CPUS_PER_TASK: 16
+#    OMP_NUM_THREADS: $SLURM_CPUS_PER_TASK
+#    SLURM_NTASKS: 4
+#  script:
+#    - cd SIRIUS/test/Si63Ge
+#    - /opt/sirius-gpu/bin/sirius.scf --test_against=output_ref.json
+
+#run cp2k develop hohgant a100 mpi-hook:
+#  extends: .run-test-hohgant-a100
+#  needs: ["build sirius-develop image"]
+#  variables:
+#    USE_MPI: 'YES'
+#    SLURM_JOB_NUM_NODES: 1
+#    SLURM_CPUS_PER_TASK: 16
+#    OMP_NUM_THREADS: $SLURM_CPUS_PER_TASK
+#    SLURM_NTASKS: 4
+#  script:
+#    - cd SIRIUS/test/Si63Ge
+#    - /opt/sirius-gpu/bin/sirius.scf --control.mpi_grid_dims=1:4 --test_against=output_ref.json

--- a/CP2K/gcc-mkl-cpu/Dockerfile
+++ b/CP2K/gcc-mkl-cpu/Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:23.04 as builder
+
+ARG CUDA_ARCH=80
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV FORCE_UNSAFE_CONFIGURE 1
+
+ENV PATH="/spack/bin:${PATH}"
+
+ENV MPICH_VERSION=4.0.3
+ENV CMAKE_VERSION=3.25.2
+RUN apt-get update -qq
+RUN apt-get install -qq --no-install-recommends autoconf autogen automake autotools-dev bzip2 ca-certificates g++ gcc gfortran git less libtool libtool-bin make nano patch pkg-config python3 unzip wget xxd zlib1g-dev cmake gnupg m4 xz-utils libssl-dev libssh-dev 
+RUN wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386 && chmod a+x /usr/local/bin/yq
+# get latest version of spack
+RUN git clone https://github.com/spack/spack.git
+RUN git clone https://github.com/eth-cscs/cp2k.git
+RUN cd cp2k && git checkout cicd && cd ..
+
+# set the location of packages built by spack
+RUN spack config add config:install_tree:root:/opt/spack
+# set cuda_arch for all packages
+# RUN spack config add packages:all:variants:cuda_arch=${CUDA_ARCH}
+
+# find all external packages
+RUN spack external find --all --exclude python
+# find compilers
+RUN spack compiler find
+# tweaking the arguments
+RUN yq -i '.compilers[0].compiler.flags.fflags = "-fallow-argument-mismatch"' /root/.spack/linux/compilers.yaml
+
+# copy bunch of things from the ci
+RUN ls -lap /cp2k/ci 
+RUN cp -r /cp2k/ci/spack /root/spack-recipe
+RUN spack repo add /root/spack-recipe/ --scope user
+
+# for the MPI hook
+RUN echo $(spack find --format='{prefix.lib}' mpich) > /etc/ld.so.conf.d/mpich.conf
+RUN ldconfig
+
+# no need to use spla offloading on cpu only version
+ENV SPACK_ROOT=/spack 
+ENV SPEC_MKL="cp2k@master%gcc build_system=cmake build_type=Release +sirius +elpa +libxc +libint smm=libxsmm +spglib +cosma +mpi +openmp ^intel-oneapi-mkl+cluster ^cosma+scalapack+shared ^mpich@${MPICH_VERSION}"
+
+# install all dependencies
+RUN spack env create -d /opt/cp2k-cpu
+RUN spack -e /opt/cp2k-cpu  add $SPEC_MKL 
+RUN spack -e /opt/cp2k-cpu install --only=dependencies --fail-fast $SPEC_MKL
+RUN spack --color always -e /opt/cp2k-cpu dev-build -q --source-path /cp2k $SPEC_MKL

--- a/CP2K/gcc-mkl-gpu/AMD.Dockerfile
+++ b/CP2K/gcc-mkl-gpu/AMD.Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:23.04 as builder
+
+ARG CUDA_ARCH=80
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV FORCE_UNSAFE_CONFIGURE 1
+
+ENV PATH="/spack/bin:${PATH}"
+
+ENV MPICH_VERSION=4.0.3
+ENV CMAKE_VERSION=3.25.2
+RUN apt-get update -qq
+RUN apt-get install -qq --no-install-recommends autoconf autogen automake autotools-dev bzip2 ca-certificates g++ gcc gfortran git less libtool libtool-bin make nano patch pkg-config python3 unzip wget xxd zlib1g-dev cmake gnupg m4 xz-utils libssl-dev libssh-dev 
+RUN wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386 && chmod a+x /usr/local/bin/yq
+# get latest version of spack
+RUN git clone https://github.com/spack/spack.git
+RUN git clone https://github.com/eth-cscs/cp2k.git
+RUN cd cp2k && git checkout cicd && cd ..
+
+# set the location of packages built by spack
+RUN spack config add config:install_tree:root:/opt/spack
+# set cuda_arch for all packages
+# RUN spack config add packages:all:variants:cuda_arch=${CUDA_ARCH}
+
+# find all external packages
+RUN spack external find --all --exclude python
+# find compilers
+RUN spack compiler find
+# tweaking the arguments
+RUN yq -i '.compilers[0].compiler.flags.fflags = "-fallow-argument-mismatch"' /root/.spack/linux/compilers.yaml
+
+# copy bunch of things from the ci
+RUN ls -lap /cp2k/ci 
+RUN cp -r /cp2k/ci/spack /root/spack-recipe
+RUN spack repo add /root/spack-recipe/ --scope user
+
+# for the MPI hook
+RUN echo $(spack find --format='{prefix.lib}' mpich) > /etc/ld.so.conf.d/mpich.conf
+RUN ldconfig
+
+# no need to use spla offloading on cpu only version
+ENV SPACK_ROOT=/spack 
+ENV SPEC_MKL="cp2k@master%gcc build_system=cmake build_type=Release +sirius +elpa +libxc +libint smm=libxsmm +spglib +cosma +mpi +openmp ^intel-oneapi-mkl+cluster ^cosma+scalapack+shared+rocm ^mpich@${MPICH_VERSION} ^dbcsr+rocm "
+
+# install all dependencies
+RUN spack env create -d /opt/cp2k-amd-gpu
+RUN spack -e /opt/cp2k-amd-gpu  add $SPEC_MKL 
+RUN spack -e /opt/cp2k-amd-gpu install --only=dependencies --fail-fast $SPEC_MKL
+RUN spack --color always -e /opt/cp2k-amd-gpu dev-build -q --source-path /cp2k $SPEC_MKL

--- a/CP2K/gcc-mkl-gpu/nvidia.Dockerfile
+++ b/CP2K/gcc-mkl-gpu/nvidia.Dockerfile
@@ -1,0 +1,50 @@
+FROM ubuntu:23.04 as builder
+
+ARG CUDA_ARCH=80
+
+ENV DEBIAN_FRONTEND noninteractive
+
+ENV FORCE_UNSAFE_CONFIGURE 1
+
+ENV PATH="/spack/bin:${PATH}"
+
+ENV MPICH_VERSION=4.0.3
+ENV CMAKE_VERSION=3.25.2
+RUN apt-get update -qq
+RUN apt-get install -qq --no-install-recommends autoconf autogen automake autotools-dev bzip2 ca-certificates g++ gcc gfortran git less libtool libtool-bin make nano patch pkg-config python3 unzip wget xxd zlib1g-dev cmake gnupg m4 xz-utils libssl-dev libssh-dev 
+RUN wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_386 && chmod a+x /usr/local/bin/yq
+# get latest version of spack
+RUN git clone https://github.com/spack/spack.git
+RUN git clone https://github.com/eth-cscs/cp2k.git
+RUN cd cp2k && git checkout cicd && cd ..
+
+# set the location of packages built by spack
+RUN spack config add config:install_tree:root:/opt/spack
+# set cuda_arch for all packages
+# RUN spack config add packages:all:variants:cuda_arch=${CUDA_ARCH}
+
+# find all external packages
+RUN spack external find --all --exclude python
+# find compilers
+RUN spack compiler find
+# tweaking the arguments
+RUN yq -i '.compilers[0].compiler.flags.fflags = "-fallow-argument-mismatch"' /root/.spack/linux/compilers.yaml
+
+# copy bunch of things from the ci
+RUN ls -lap /cp2k/ci 
+RUN cp -r /cp2k/ci/spack /root/spack-recipe
+RUN spack repo add /root/spack-recipe/ --scope user
+
+# for the MPI hook
+RUN echo $(spack find --format='{prefix.lib}' mpich) > /etc/ld.so.conf.d/mpich.conf
+RUN ldconfig
+
+# no need to use spla offloading on cpu only version
+ENV SPACK_ROOT=/spack 
+ENV SPEC_MKL="cp2k@master%gcc build_system=cmake build_type=Release ~libint smm=libxsmm +spglib +cosma +mpi +openmp +cuda cuda_arch=${CUDA_ARCH} ^intel-oneapi-mkl+cluster ^cosma+scalapack+shared+cuda~apps~tests ^mpich@${MPICH_VERSION} ^dbcsr+cuda cuda_arch=70"
+
+# install all dependencies
+RUN spack env create -d /opt/cp2k-nvidia-gpu
+RUN spack -e /opt/cp2k-nvidia-gpu  add $SPEC_MKL 
+RUN spack -e /opt/cp2k-nvidia-gpu install --only=dependencies --fail-fast $SPEC_MKL
+RUN spack --color always -e /opt/cp2k-nvidia-gpu dev-build -q --source-path /cp2k $SPEC_MKL


### PR DESCRIPTION
All docker containers use spack to build cp2k and its dependencies
- CPU version compiles without any problem
- GPU version fails on ubuntu 23.

I still need to set the ci/cd.