### PR TITLE
fetch credentials from middleware

### DIFF
--- a/ci/common.yml
+++ b/ci/common.yml
@@ -35,6 +35,7 @@ include:
   variables:
     GIT_STRATEGY: fetch
   script:
+    - !reference [.fetch-registry-tokens, script]
     - echo -e "$CSCS_REGISTRY_USER\n$CSCS_REGISTRY_PASSWORD" | sarus pull --login $BASE_IMAGE
     - rm -rf cscs-reframe-tests
     - git clone https://github.com/eth-cscs/cscs-reframe-tests.git


### PR DESCRIPTION
Soon static tokens will be removed, and tokens must be fetched explicitly when needed from the middleware. These tokens will be valid only for the duration of the job.